### PR TITLE
bytebuffer apend crashfix

### DIFF
--- a/src/shared/ByteBuffer.h
+++ b/src/shared/ByteBuffer.h
@@ -399,7 +399,7 @@ class ByteBuffer
 
         void append(const ByteBuffer& buffer)
         {
-            if(buffer.wpos())
+            if(buffer.size())
                 append(buffer.contents(), buffer.wpos());
         }
 


### PR DESCRIPTION
I found, I believe, a very scary bug.

https://github.com/elysium-project/server/blob/development/src/shared/ByteBuffer.h#L402

On a call to SendMeleeAttackStop() from map update, I am assuming because I was targetting a temprary creature spawn that despawned as as it happened (i have reproduced this multiple times btw), buffer.wpos() returned 8, while buffer.size() is 0. Thus, when buffer.contents() try to run return &_storage[0]; a crash happens.(edited)

I attempted to replace buffer.wpos() with buffer.size(), and I am no longer able to reproduce the bug, but this is really old code from what I can find, so it strikes me as odd that i's always been buffer.wpos(), and noone has noticed or done anything about it
is anyone more familiar with the ByteBuffer class able to see if .size() is a valid replacement for .wpos()? It seems much safer to me. I assume the idea is that wpos should always be safe to use, but wpos can be changed a ton of places so its hard to imagine it can't fail (as it did for me now)

